### PR TITLE
Ship rtail-server as a container image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.github
+.claude
+node_modules
+dist
+app/css
+app/bundle.js
+app/bundle.js.map
+*.log
+Makefile
+README.md

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,47 @@
+name: Docker
+
+# Never fires on its own: only on a version tag you push, or a manual run.
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,61 @@
+# syntax=docker/dockerfile:1
+#
+# Runtime image for rtail-server — the default way to run rtail.
+#
+#   docker build -t rtail .
+#   docker run --rm -p 8888:8888 -p 9999:9999/udp rtail
+#
+# This is the *server*. The rtail client is a pipe on your host and is not
+# meant to run in here; install it with npm, or pipe into the container's UDP
+# port from anywhere on the network.
+#
+# Not to be confused with tools/Dockerfile, which is the development toolchain
+# and mounts your checkout.
+
+# ---- build the webapp ------------------------------------------------------
+FROM node:22.12.0-bookworm-slim AS build
+
+WORKDIR /src
+
+# Copy manifests first so the dependency layer is cached independently of source.
+COPY package.json package-lock.json ./
+RUN npm ci --no-audit --no-fund
+
+COPY . .
+RUN npm run dist
+
+# ---- runtime ---------------------------------------------------------------
+FROM node:22.12.0-bookworm-slim AS runtime
+
+# update-notifier phones npm on startup and prints a banner nobody can act on
+# from inside a container image.
+ENV NODE_ENV=production \
+    NO_UPDATE_NOTIFIER=1 \
+    NPM_CONFIG_UPDATE_NOTIFIER=false
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev --no-audit --no-fund \
+ && npm cache clean --force
+
+COPY --from=build /src/cli ./cli
+COPY --from=build /src/dist ./dist
+
+# A container's loopback is its own; binding 127.0.0.1 would make the published
+# ports unreachable. Set as env rather than in CMD so that `docker run rtail
+# --web-port 9000` appends a flag instead of dropping the bind address.
+ENV RTAIL_WEB_HOST=0.0.0.0 \
+    RTAIL_UDP_HOST=0.0.0.0 \
+    RTAIL_WEB_PORT=8888 \
+    RTAIL_UDP_PORT=9999
+
+EXPOSE 8888/tcp
+EXPOSE 9999/udp
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD node -e "fetch('http://127.0.0.1:'+(process.env.RTAIL_WEB_PORT||8888)+'/').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+
+USER node
+
+ENTRYPOINT ["node", "cli/rtail-server.js"]

--- a/README.md
+++ b/README.md
@@ -11,11 +11,38 @@
 
 `rtail` is a command line utility that grabs every line in `stdin` and broadcasts it over **UDP**. That's it. Nothing fancy. Nothing complicated. Tail log files, app output, or whatever you wish, using `rtail` broadcasting to an `rtail-server` – See multiple streams in the browser, in realtime.
 
-## Installation
+## Running the server
 
-Requires Node.js 20 or newer.
+The server ships as a container image — this is the recommended way to run it.
+
+    $ docker run -d --name rtail -p 8888:8888 -p 9999:9999/udp ghcr.io/kilianc/rtail
+
+Open <http://localhost:8888> and start piping. There is a
+[`docker-compose.yml`](docker-compose.yml) if you prefer:
+
+    $ docker compose up -d
+
+Options are flags, or `RTAIL_*` environment variables:
+
+    $ docker run -d -p 8080:8080 -p 9999:9999/udp \
+        -e RTAIL_WEB_PORT=8080 ghcr.io/kilianc/rtail
+
+    $ docker run -d -p 8888:8888 -p 9999:9999/udp \
+        ghcr.io/kilianc/rtail --backlog 500
+
+The image binds `0.0.0.0` inside the container, so **the published ports are
+reachable from your whole network**. It has no authentication — keep it on a
+trusted network, or put a reverse proxy in front of it.
+
+## Installing the client
+
+The client is a UNIX pipe and belongs on the host whose output you are tailing,
+not in the container. It needs Node.js 20 or newer:
 
     $ npm install -g rtail
+
+`npm install -g rtail` also gives you `rtail-server`, if you would rather run
+the server without Docker.
 
 ## Web app
 
@@ -126,8 +153,13 @@ Open your browser and start tailing logs!
     --web-host, --wh  The listening HTTP hostname           [default: "127.0.0.1"]
     --web-port, --wp  The listening HTTP port                      [default: 8888]
     --web-version     Define web app version to serve                     [string]
+    --backlog, -b     Lines of history kept per stream    [number] [default: 100]
     --help, -h        Show help                                          [boolean]
     --version, -v     Show version number                                [boolean]
+
+Every option can also be set as an environment variable, prefixed with
+`RTAIL_` — `RTAIL_WEB_PORT=8080`, `RTAIL_BACKLOG=500`, and so on. This is how
+the container image is configured.
 
     Examples:
     rtail-server --web-port 8080         Use custom HTTP port
@@ -145,6 +177,11 @@ To scale and broadcast on multiple servers, instruct the `rtail` client to strea
 For the time being, the webapp doesn't have an authentication layer; it assumes that you will run it behind a VPN or reverse proxy, with a simple `Authorization` header check.
 
 # Running it locally
+
+Note there are two images, and they are not the same thing:
+[`Dockerfile`](Dockerfile) is the server you deploy, and
+[`tools/Dockerfile`](tools/Dockerfile) below is the development toolchain,
+which mounts your checkout.
 
 The toolchain lives in a container ([`tools/Dockerfile`](tools/Dockerfile)), so Docker is
 the only thing you need installed — no Node.js, no npm, no global CLIs.
@@ -230,13 +267,29 @@ CI runs both, plus the production build, on Node 20 and 22.
 
 ## Roadmap (aka where you can help)
 
-* Write a rock solid test suite
-* Allow use of DTLS (waiting for node to support this https://github.com/joyent/node/pull/6704)
-* Add GitHub OAuth and basic auth for teams (join proposal convo here: https://github.com/kilianc/rtail/issues/44)
-* Implement infinite-scroll like behavior in the webapp to support bigger backlogs and make it future proof.
-* Publish base rtail docker image to DockerHub
-* Create a catch all docker logs image
-* Rewrite webapp using ng2
+* Optional HTTP basic auth on the web port, and a shared secret on UDP ingest.
+  Full OAuth ([#44](https://github.com/kilianc/rtail/issues/44)) needs a user
+  model and session storage, which is a lot of machinery for a tool with no
+  persistence layer — basic auth covers the actual risk.
+* A catch-all docker logs image: watch `docker events`, pipe every container's
+  `docker logs -f` into a stream named after it.
+* Broaden the test suite, particularly around the UDP ingest path.
+
+Dropped, and why:
+
+* ~~Rewrite webapp using ng2~~ — done differently. The webapp is now Preact +
+  TypeScript; Angular 2 was already obsolete by the time it came up.
+* ~~Publish base rtail docker image to DockerHub~~ — done, but to GHCR rather
+  than DockerHub, since it needs no separate account or secrets.
+* ~~Write a rock solid test suite~~ — a suite exists and runs in CI. Deepening
+  it is the open item above.
+* ~~Allow use of DTLS~~ — the linked PR was against `joyent/node`, a repo that
+  no longer exists, and Node core still has no DTLS. Run rtail over WireGuard
+  or Tailscale instead; that is the modern answer to this problem.
+* ~~Infinite-scroll in the webapp~~ — cannot be built as stated. The server
+  keeps a fixed-size ring buffer per stream and sends it in one message; there
+  is no pagination to scroll through. Real history means a persistence layer,
+  which contradicts the design. `--backlog` covers the useful part.
 
 ## Sponsors
 ❤ rTail? Consider sponsoring this project to keep it alive and free for the community.

--- a/cli/rtail-server.js
+++ b/cli/rtail-server.js
@@ -61,6 +61,22 @@ const argv = yargs(hideBin(process.argv))
     type: 'string',
     describe: 'Define web app version to serve'
   })
+  .option('backlog', {
+    alias: 'b',
+    type: 'number',
+    default: 100,
+    describe: 'Lines of history kept in memory, per stream'
+  })
+  .check((args) => {
+    if (!Number.isInteger(args.backlog) || args.backlog < 1) {
+      throw new Error('--backlog must be a positive integer')
+    }
+    return true
+  })
+  // Every option is also settable as RTAIL_*, e.g. RTAIL_WEB_HOST. The
+  // container image sets the listen hosts this way so that `docker run rtail`
+  // with extra flags appends to the command instead of replacing it.
+  .env('RTAIL')
   .help('help')
   .alias('help', 'h')
   .version(pkg.version)
@@ -68,7 +84,7 @@ const argv = yargs(hideBin(process.argv))
   .strict()
   .parseSync()
 
-const BACKLOG_SIZE = 100
+const BACKLOG_SIZE = argv.backlog
 
 const app = express()
 const http = createServer(app)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+# Run rtail-server.
+#
+#   docker compose up -d
+#
+# Then point clients at this host's UDP port:
+#
+#   mycommand | rtail --host <this-host>
+#
+# `build: .` is here so the file works straight from a checkout; delete it to
+# always pull the published image instead.
+
+services:
+  rtail:
+    image: ghcr.io/kilianc/rtail:latest
+    build: .
+    restart: unless-stopped
+    ports:
+      - '8888:8888'
+      - '9999:9999/udp'
+    environment:
+      # Uncomment to see every line the server ingests.
+      # DEBUG: 'rtail:*'
+      RTAIL_WEB_PORT: '8888'
+      RTAIL_UDP_PORT: '9999'


### PR DESCRIPTION
Running the server meant installing Node and a global npm package. This makes the container image the default way to run it.

`tools/Dockerfile` already covers the *development* toolchain — this adds the missing *production* image.

## What's here

- **`Dockerfile`** — multi-stage: builds the webapp, then a slim runtime with production dependencies only, non-root, with a healthcheck.
- **`docker-compose.yml`**, **`.dockerignore`**
- **`.github/workflows/docker.yml`** — publishes to GHCR. Fires only on a `v*` tag or a manual run, so it cannot publish on its own.
- **`cli/rtail-server.js`** — reads `RTAIL_*` environment variables, and `--backlog` is now a flag rather than a hardcoded 100.
- **README** — Docker documented as the default; roadmap rewritten.

## Two design notes

The container binds `0.0.0.0`, because a container's loopback is its own and `127.0.0.1` would make the published ports unreachable.

The bind addresses are set as `ENV` rather than in `CMD`, so `docker run rtail --backlog 500` appends a flag instead of silently dropping them. That's what required teaching the server to read `RTAIL_*`.

## Roadmap

Several items were completed by the Preact rewrite. Of the rest:

- **Dropped — DTLS**: the linked PR was against `joyent/node`, which no longer exists, and Node core still has no DTLS. WireGuard or Tailscale is the modern answer.
- **Dropped — infinite scroll**: can't be built as stated. The server keeps a fixed-size ring buffer per stream and sends it in one message; there's no pagination to scroll through. Real history means a persistence layer, which contradicts the design. `--backlog` covers the useful part.
- **Kept** — basic auth (rather than full OAuth), the catch-all docker logs image, and deeper tests around UDP ingest.

Note the image publishes to **GHCR**, not DockerHub as the roadmap said — it needs no separate account or secrets.

## Verification

Built and ran the image, and confirmed the full path: HTTP 200, socket.io handshake, a UDP packet from the host reaching the server, and the webapp rendering lines live in the browser with both streams listed. Healthcheck reports `healthy`.

Test suite: 25/25 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)