### PR TITLE
Move to a single main branch, with version bumps cutting releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,15 @@
 name: CI
 
+# Every change reaches main through a pull request, so a PR run and a post-merge
+# run on main are the only two that matter.
 on:
   push:
-    branches: ['**']
+    branches: [main]
   pull_request:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,10 +1,28 @@
 name: Docker
 
-# Never fires on its own: only on a version tag you push, or a manual run.
+# Never fires on its own: the Release workflow calls it once a version bump has
+# been tagged, or you run it by hand to re-push an image.
 on:
-  push:
-    tags: ['v*']
+  workflow_call:
+    inputs:
+      version:
+        description: 'Version to tag the image with, e.g. 0.2.1'
+        required: true
+        type: string
+      latest:
+        description: 'Also push the `latest` tag'
+        default: true
+        type: boolean
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to tag the image with, e.g. 0.2.1'
+        required: true
+        type: string
+      latest:
+        description: 'Also push the `latest` tag'
+        default: true
+        type: boolean
 
 jobs:
   publish:
@@ -32,9 +50,9 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{version}},value=${{ inputs.version }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.version }}
+            type=raw,value=latest,enable=${{ inputs.latest }}
 
       - uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,109 @@
+name: Release
+
+# The version in package.json is the release trigger. Bump it in a PR; when that
+# PR lands on main this tags the commit, cuts the GitHub release, and ships the
+# container image.
+on:
+  push:
+    branches: [main]
+    paths: ['package.json']
+
+jobs:
+  version:
+    runs-on: ubuntu-latest
+
+    outputs:
+      changed: ${{ steps.check.outputs.changed }}
+      version: ${{ steps.check.outputs.version }}
+      prerelease: ${{ steps.check.outputs.prerelease }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # HEAD^ for the version diff, and the tags for the already-released
+          # guard — neither comes with the default shallow checkout.
+          fetch-depth: 2
+          fetch-tags: true
+
+      - id: check
+        name: Detect a version bump
+        run: |
+          version=$(jq -r .version package.json)
+          previous=$(git show HEAD^:package.json 2>/dev/null | jq -r .version || echo '')
+
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+          if [ "$version" = "$previous" ]; then
+            echo "Version unchanged at $version — nothing to release."
+            echo 'changed=false' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if git rev-parse -q --verify "refs/tags/v$version" >/dev/null; then
+            echo "Tag v$version already exists — nothing to release."
+            echo 'changed=false' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "$previous -> $version"
+          echo 'changed=true' >> "$GITHUB_OUTPUT"
+
+          # 0.3.0-rc.1 and friends ship, but never as `latest`.
+          case "$version" in
+            *-*) echo 'prerelease=true' >> "$GITHUB_OUTPUT" ;;
+            *) echo 'prerelease=false' >> "$GITHUB_OUTPUT" ;;
+          esac
+
+  verify:
+    needs: version
+    if: needs.version.outputs.changed == 'true'
+    runs-on: ubuntu-latest
+
+    # Releases are cut straight from main, so re-run the gate here rather than
+    # trusting that CI already passed on this commit.
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+
+      - run: npm ci
+      - run: npm run typecheck
+      - run: npm run dist
+      - run: npm test
+
+  release:
+    needs: [version, verify]
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Tag and publish the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.version.outputs.version }}
+          PRERELEASE: ${{ needs.version.outputs.prerelease }}
+        run: |
+          flags=''
+          [ "$PRERELEASE" = 'true' ] && flags='--prerelease'
+
+          gh release create "v$VERSION" \
+            --title "v$VERSION" \
+            --target "$GITHUB_SHA" \
+            --generate-notes $flags
+
+  docker:
+    needs: [version, release]
+    uses: ./.github/workflows/docker.yml
+    permissions:
+      contents: read
+      packages: write
+    with:
+      version: ${{ needs.version.outputs.version }}
+      latest: ${{ needs.version.outputs.prerelease == 'false' }}

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ the container image is configured.
     rtail-server --web-port 8080         Use custom HTTP port
     rtail-server --udp-port 8080         Use custom UDP port
     rtail-server --web-version stable    Always uses latest stable webapp
-    rtail-server --web-version unstable  Always uses latest develop webapp
+    rtail-server --web-version unstable  Always uses latest unreleased webapp
     rtail-server --web-version 0.1.3     Use webapp v0.1.3
 
 ## UDP Broadcasting
@@ -240,10 +240,11 @@ platform (`history`, `localStorage`, `Intl`) rather than dependencies.
 
 # How to contribute
 
-This project follows the awesome [Vincent Driessen](http://nvie.com/about/) [branching model](http://nvie.com/posts/a-successful-git-branching-model/).
+`main` is the only long-lived branch, and it is always releasable.
 
-* You must add a new feature on its own branch
-* You must contribute to hot-fixing, directly into the master branch (and pull-request to it)
+* Branch off `main`, and open a pull request back into `main`
+* Keep the branch short-lived; there is no `develop` or release branch to merge through
+* CI must be green before a pull request lands
 
 The test suite runs on the built-in [`node:test`](https://nodejs.org/api/test.html)
 runner. Use the tests to check whether your contribution breaks some part of the
@@ -256,6 +257,17 @@ The webapp is TypeScript; please keep it type-clean:
     $ make typecheck
 
 CI runs both, plus the production build, on Node 20 and 22.
+
+## Releasing
+
+The `version` field in `package.json` is the release trigger. Bump it in a pull
+request like any other change; when that pull request lands on `main`, CI
+re-runs the type-check, build, and tests, then tags the commit `vX.Y.Z`, cuts a
+GitHub release with generated notes, and pushes the multi-arch container image
+to `ghcr.io/kilianc/rtail`.
+
+A version with a pre-release suffix (`0.3.0-rc.1`) is marked as a pre-release
+and is never tagged `latest`. Landing anything else on `main` releases nothing.
 
 ## Contributors
 

--- a/cli/rtail-server.js
+++ b/cli/rtail-server.js
@@ -31,7 +31,7 @@ const argv = yargs(hideBin(process.argv))
   .example('rtail-server --web-port 8080', 'Use custom HTTP port')
   .example('rtail-server --udp-port 8080', 'Use custom UDP port')
   .example('rtail-server --web-version stable', 'Always uses latest stable webapp')
-  .example('rtail-server --web-version unstable', 'Always uses latest develop webapp')
+  .example('rtail-server --web-version unstable', 'Always uses latest unreleased webapp')
   .example('rtail-server --web-version 0.1.3', 'Use webapp v0.1.3')
   .option('udp-host', {
     alias: 'uh',


### PR DESCRIPTION
`develop` has been renamed to `main` and is now the default branch. This makes the tooling and docs match.

## Branching

All work branches off `main` and returns through a pull request. CI runs on pull requests and on `main` — no longer on every pushed branch, which was running each PR branch twice — and cancels superseded pull-request runs.

## Releases

The `version` field in `package.json` is the release trigger. When a bump lands on `main`, Release re-runs type-check, build, and tests, tags the commit `vX.Y.Z`, cuts a GitHub release with generated notes, and publishes the container image. Landing anything else releases nothing.

A version carrying a pre-release suffix (`0.3.0-rc.1`) is marked as a pre-release and is never tagged `latest`.

Two guards keep it from firing twice: the version must differ from `HEAD^`, and the tag must not already exist. The checkout fetches tags and two commits of depth so both can actually be evaluated.

## Docker

`docker.yml` became a reusable workflow taking `version` and `latest` inputs, and no longer triggers on `v*` tags. A tag pushed by `GITHUB_TOKEN` does not start another workflow run, so the tag trigger would never have fired for an automated release — Release calls the workflow directly instead. `workflow_dispatch` still works for re-pushing an image by hand.

## Stale branches

`master`, `ui`, and `website` are deleted. `ui` and `website` held commits reachable from nowhere else, so all three tips are preserved as `archive/master`, `archive/ui`, and `archive/website`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)