### PR TITLE
Query the stream, extract JSON fields, and stop expanding every payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,58 @@ the container image is configured.
     rtail-server --web-version unstable  Always uses latest develop webapp
     rtail-server --web-version 0.1.3     Use webapp v0.1.3
 
+## The web view
+
+### Filtering
+
+The filter box takes a small query language rather than a bare regexp. Terms
+are separated by spaces and **all** of them have to match; matching ignores
+case until a term contains a capital, the way `ag` and `rg` behave.
+
+| Query               | Matches                                          |
+| ------------------- | ------------------------------------------------ |
+| `payment failed`    | both words, in any order                         |
+| `"payment failed"`  | that exact phrase                                |
+| `-healthcheck`      | lines without it                                 |
+| `/GET \/1\/users/`  | a regexp — add `/i`, `/s`, `/m` or `/u` for flags |
+| `level:error`       | the JSON field contains `error`                  |
+| `user.id=42`        | the JSON field is exactly `42`                   |
+| `status!=200`       | it is anything else                              |
+| `duration>250`      | `>`, `>=`, `<` and `<=`, on numbers              |
+| `tags[0]:api`       | paths index into arrays                          |
+| `trace_id:*`        | the field is there at all                        |
+
+Field terms read the parsed payload, so `level:error` cannot be fooled by the
+word "error" sitting in a message three keys away. A field term never matches a
+line that does not carry the field — including `status!=200`, which means "has
+a status, and it is not 200". For "not 200, whether or not there is a status",
+negate the whole term instead: `-status:200`.
+
+Matches are marked in the viewport, and the box counts how many lines survived.
+An unfinished regexp turns the box's hairline red and keeps filtering on the
+terms that did parse. Press `f` to jump to the box, `Escape` to clear it.
+
+### Extracting fields
+
+`Fields` picks JSON paths out of object lines: `event=checkout.completed
+count=305 ok=false` instead of the whole payload. The list is a census of the
+paths in the buffer, most common first, and takes a hand-typed path for
+anything that has not come past yet. The picks belong to the stream — the
+fields of a billing worker are not the fields of an nginx log — and are
+remembered per stream.
+
+### JSON payloads
+
+Not every payload is worth six rows of the viewport. **Settings → JSON
+payloads** decides what an object line looks like before you touch it:
+
+* **Auto** (default) — expanded up to six rows, collapsed past that.
+* **One line** — always collapsed, truncated at the edge of the window.
+* **Pretty** — always expanded.
+
+The caret at the start of any object line overrides that for that line, whether
+it is showing a payload or extracted fields.
+
 ## UDP Broadcasting
 
 To scale and broadcast on multiple servers, instruct the `rtail` client to stream to the broadcast address. Every message will then be delivered to all servers in your subnet.

--- a/app/scss/_highlightjs.scss
+++ b/app/scss/_highlightjs.scss
@@ -3,7 +3,7 @@
 // **
 
 .stream-line-content pre {
-  color: var(--text-secondary);
+  color: var(--foreground);
 }
 
 .hljs-attr,
@@ -25,5 +25,5 @@
 }
 
 .hljs-punctuation {
-  color: var(--text-faint);
+  color: var(--muted-foreground);
 }

--- a/app/scss/main.scss
+++ b/app/scss/main.scss
@@ -188,14 +188,11 @@
     padding-inline: var(--space-4) var(--space-2);
   }
 
-  // One flexible gap, wherever the right-hand group starts. Two `auto` margins
-  // would split the free space between them instead of pushing one group over.
+  // The filter takes every spare pixel (see below), so this margin is only
+  // ever load-bearing when there is no filter in the bar — no stream selected,
+  // or a bar too narrow to carry one. Then it pushes the actions to the edge.
   .topbar-actions {
     display: flex;
-  }
-
-  .topbar-main:has(.filter-box) .filter-box,
-  .topbar-main:not(:has(.filter-box)) .topbar-actions {
     margin-inline-start: auto;
   }
 
@@ -313,27 +310,101 @@
     }
   }
 
+  // The fill is on the box rather than the input, because the box holds more
+  // than the input: the match count, the clear cross and the syntax card's
+  // trigger all sit inside the same filled rectangle.
   .filter-box {
+    background: var(--muted);
+    block-size: var(--control-h);
+    gap: var(--space-2);
+    // icon inset + icon + gap
+    padding-inline: calc(var(--space-2) * 2 + var(--icon-sm)) var(--space-2);
+    transition: background-color .12s ease, box-shadow .12s ease;
+
     &::before {
       @include icon-common('icn-filter');
       inset-inline-start: var(--space-2);
     }
 
+    &:hover {
+      box-shadow: inset 0 0 0 var(--hairline) var(--border);
+    }
+
+    &:focus-within {
+      background: var(--background);
+      box-shadow: inset 0 0 0 var(--hairline) var(--border-strong);
+    }
+
+    // A half-typed regexp, most of the time. The hairline says so without
+    // moving anything: the lines that did parse are still filtering.
+    &.invalid,
+    &.invalid:focus-within {
+      box-shadow: inset 0 0 0 var(--hairline) var(--ansi-red);
+    }
+
     input {
-      background: var(--muted);
-      block-size: var(--control-h);
-      // icon inset + icon + gap
-      padding-inline: calc(var(--space-2) * 2 + var(--icon-sm)) var(--space-2);
-      transition: background-color .12s ease, box-shadow .12s ease;
+      block-size: 100%;
+    }
+  }
 
-      &:hover {
-        box-shadow: inset 0 0 0 var(--hairline) var(--border);
-      }
+  .filter-count {
+    color: var(--muted-foreground);
+    flex-shrink: 0;
+    font-size: var(--text-xs);
+    font-variant-numeric: tabular-nums;
+    user-select: none;
+  }
 
-      &:focus {
-        background: var(--background);
-        box-shadow: inset 0 0 0 var(--hairline) var(--border-strong);
-      }
+  .filter-help {
+    color: var(--muted-foreground);
+    flex-shrink: 0;
+    font-size: var(--text-xs);
+    line-height: 1;
+    transition: color .12s ease;
+
+    &:hover,
+    &[aria-expanded='true'] {
+      color: var(--foreground);
+    }
+  }
+
+  // ** field extraction **
+
+  .btn-fields {
+    align-items: center;
+    block-size: var(--control-h);
+    box-shadow: inset 0 0 0 var(--hairline) var(--border);
+    color: var(--muted-foreground);
+    display: flex;
+    flex-shrink: 0;
+    font-size: var(--text-sm);
+    gap: var(--space-2);
+    padding-inline: var(--space-3);
+    transition: background-color .12s ease, box-shadow .12s ease, color .12s ease;
+
+    &:hover,
+    &[aria-expanded='true'] {
+      background: var(--subtle);
+      color: var(--foreground);
+    }
+
+    // Extraction changes what every object line shows, so the button carries
+    // the count: it is the one setting you want to see without opening it.
+    &.on {
+      box-shadow: inset 0 0 0 var(--hairline) var(--border-strong);
+      color: var(--foreground);
+    }
+
+    .btn-fields-count {
+      background: var(--primary);
+      block-size: var(--space-4);
+      color: var(--primary-foreground);
+      display: grid;
+      font-size: var(--text-xs);
+      font-variant-numeric: tabular-nums;
+      min-inline-size: var(--space-4);
+      padding-inline: var(--space-1);
+      place-items: center;
     }
   }
 
@@ -485,13 +556,16 @@
     }
   }
 
+  // Every pixel the title, the status and the actions do not need. The filter
+  // is the control you type into most, and the queries are long: a field path,
+  // a comparison and a phrase run past any width worth hardcoding.
   .topbar .filter-box {
-    inline-size: calc(var(--space-6) * 10);
+    flex: 1;
   }
 
-  // Below this width the filter box is the first thing to go.
+  // Below this width the filter and its field picker are the first to go.
   @container (max-width: 640px) {
-    .topbar .filter-box {
+    .topbar :is(.filter-box, .btn-fields) {
       display: none;
     }
   }
@@ -641,11 +715,73 @@
     .stream-line-content {
       min-inline-size: 0;
       white-space: pre;
+
+      // Only object lines carry the caret, and only they need a positioning
+      // context for it.
+      &.json {
+        position: relative;
+      }
+
+      // One line means one line: a collapsed payload is a summary, and a row
+      // that scrolls the viewport sideways is not one. Plain text lines keep
+      // overflowing as they always have — truncating a log line nobody asked
+      // to collapse would hide output.
+      &.json.collapsed :is(.stream-line-body, .stream-line-body pre) {
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+    }
+
+    .stream-line-body {
+      min-inline-size: 0;
     }
 
     pre {
       line-height: var(--line-h);
     }
+  }
+
+  // Sits in the content cell's own padding, so the text starts on the same
+  // rail as every other line whether or not there is a caret next to it.
+  .json-toggle {
+    @include icon('btn-json-expand', contain);
+    block-size: var(--space-2);
+    color: var(--muted-foreground);
+    inline-size: var(--space-2);
+    inset-block-start: calc((var(--line-h) - var(--space-2)) / 2);
+    inset-inline-start: var(--space-1);
+    position: absolute;
+    transition: color .12s ease, rotate .12s ease;
+
+    &:hover {
+      color: var(--foreground);
+    }
+
+    &[aria-expanded='true'] {
+      rotate: 90deg;
+    }
+  }
+
+  // ** extracted fields **
+  //
+  // logfmt rather than JSON: at one field per column the braces and the quotes
+  // are most of the row, and the keys repeat on every line — so the keys go
+  // quiet and the values keep the syntax colours they have in the payload.
+
+  .field-key {
+    color: var(--muted-foreground);
+  }
+
+  .field-eq {
+    color: var(--muted-foreground);
+    opacity: .5;
+  }
+
+  // The accent, doing the last thing it does in the viewport: saying where the
+  // query hit.
+  mark {
+    background: var(--primary);
+    color: var(--primary-foreground);
   }
 
   // Collapsing the column drops the track to nothing, and the control that
@@ -788,10 +924,8 @@
       }
     }
 
-    .popover-settings {
-      gap: var(--space-1);
-      padding: var(--space-3);
-
+    // Section labels and small print read the same in every panel.
+    :is(.popover-settings, .popover-help, .popover-fields) {
       h4 {
         color: var(--muted-foreground);
         font-size: var(--text-xs);
@@ -804,6 +938,147 @@
           margin-block-start: var(--space-3);
         }
       }
+
+      .hint {
+        color: var(--muted-foreground);
+        font-size: var(--text-xs);
+        line-height: 1.5;
+      }
+    }
+
+    // ** the filter's syntax card **
+
+    .popover-help {
+      gap: var(--space-2);
+      inline-size: calc(var(--space-6) * 12);
+      padding: var(--space-3);
+
+      dl {
+        display: grid;
+        gap: var(--space-1);
+      }
+
+      dl > div {
+        align-items: baseline;
+        display: flex;
+        gap: var(--space-3);
+        justify-content: space-between;
+      }
+
+      dt {
+        color: var(--foreground);
+        font-family: 'Roboto Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+        font-size: var(--mono-size);
+        white-space: nowrap;
+      }
+
+      dd {
+        color: var(--muted-foreground);
+        font-size: var(--text-xs);
+        text-align: end;
+      }
+    }
+
+    // ** the field picker **
+
+    .popover-fields {
+      gap: var(--space-2);
+      inline-size: calc(var(--space-6) * 12);
+      padding: var(--space-3);
+
+      .field-input {
+        background: var(--muted);
+        block-size: var(--control-h);
+        color: var(--foreground);
+        font-size: var(--text-sm);
+        inline-size: 100%;
+        padding-inline: var(--space-2);
+        transition: background-color .12s ease, box-shadow .12s ease;
+
+        &::placeholder {
+          color: var(--muted-foreground);
+        }
+
+        &:focus {
+          background: var(--background);
+          box-shadow: inset 0 0 0 var(--hairline) var(--border-strong);
+        }
+      }
+
+      // Tall enough for eight paths; a chattier stream scrolls rather than
+      // growing a panel past the window.
+      .field-list {
+        display: grid;
+        max-block-size: calc(var(--row-h) * 8);
+        overflow-y: auto;
+        overscroll-behavior: contain;
+      }
+
+      .field-row {
+        align-items: center;
+        color: var(--muted-foreground);
+        display: flex;
+        gap: var(--space-2);
+        min-block-size: var(--row-h);
+        padding-inline: var(--space-2);
+        position: relative;
+        text-align: start;
+        transition: background-color .12s ease, color .12s ease;
+
+        &:hover {
+          background: var(--subtle);
+          color: var(--foreground);
+        }
+
+        // Same marker as the selected stream in the sidebar: picked things are
+        // marked the same way everywhere.
+        &.on {
+          color: var(--foreground);
+
+          &::before {
+            background: var(--primary);
+            content: '';
+            inline-size: var(--marker-w);
+            inset-block: 0;
+            inset-inline-start: 0;
+            position: absolute;
+          }
+        }
+
+        .field-path {
+          font-family: 'Roboto Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+          font-size: var(--mono-size);
+          min-inline-size: 0;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
+
+        .field-count {
+          color: var(--muted-foreground);
+          font-size: var(--text-xs);
+          font-variant-numeric: tabular-nums;
+          margin-inline-start: auto;
+        }
+      }
+
+      .field-clear {
+        block-size: var(--control-h);
+        box-shadow: inset 0 0 0 var(--hairline) var(--border);
+        color: var(--foreground);
+        font-size: var(--text-sm);
+        transition: background-color .12s ease, box-shadow .12s ease;
+
+        &:hover {
+          background: var(--subtle);
+          box-shadow: inset 0 0 0 var(--hairline) var(--border-strong);
+        }
+      }
+    }
+
+    .popover-settings {
+      gap: var(--space-1);
+      padding: var(--space-3);
 
       // Segmented control: one recessed track, square cells inside it. Grid
       // with equal tracks, so two- and three-item groups both fill the rail.
@@ -856,6 +1131,16 @@
           &.btn-sorting-desc::after { @include icon('icn-sort-desc'); }
           &.btn-theme-dark::after   { @include icon('icn-theme-dark'); }
           &.btn-theme-light::after  { @include icon('icn-theme-light'); }
+
+          // Cells that say what they do in words: no icon box to reserve, and
+          // a size that fits three of them across the rail.
+          &.btn-text {
+            font-size: var(--text-sm);
+
+            &::after {
+              content: none;
+            }
+          }
         }
 
         // The font-family swatches show real glyphs, not icons.

--- a/app/src/app.tsx
+++ b/app/src/app.tsx
@@ -1,15 +1,20 @@
-import { useCallback, useEffect, useRef, useState } from 'preact/hooks'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks'
 import { Sidebar } from './components/Sidebar.js'
 import { StreamView } from './components/StreamView.js'
 import { TopBar } from './components/TopBar.js'
 import { connect, type Connection } from './lib/connection.js'
 import { formatLine } from './lib/format.js'
+import { collectPaths } from './lib/json.js'
 import { loadActiveStream, loadPrefs, savePrefs, saveActiveStream } from './lib/prefs.js'
+import { matchesQuery, parseQuery } from './lib/query.js'
 import { onRouteChange, readStream, writeStream } from './lib/router.js'
 import type { Line, Prefs } from './lib/types.js'
 
 /** Matches the server-side backlog cap. */
 const BUFFER_SIZE = 100
+
+/** Shared, so a stream with no extracted fields keeps the same array identity. */
+const NO_FIELDS: string[] = []
 
 export function App() {
   const [prefs, setPrefs] = useState<Prefs>(loadPrefs)
@@ -128,6 +133,47 @@ export function App() {
     socketRef.current?.emit('select stream', activeStreamRef.current)
   }, [])
 
+  /*!
+   * filtering
+   *
+   * Parsed once per keystroke rather than once per line, and applied here
+   * rather than in StreamView: the bar shows how many lines survived, and the
+   * viewport should not be the only place that knows.
+   */
+  const query = useMemo(() => parseQuery(filter), [filter])
+
+  // Lines arrive in order, so insertion order is the source of truth. An older
+  // implementation re-sorted by timestamp on every digest, which reordered
+  // lines that shared a millisecond.
+  const visible = useMemo(() => {
+    const matching = query.isEmpty ? lines : lines.filter((line) => matchesQuery(query, line))
+    return prefs.ascending ? matching : matching.slice().reverse()
+  }, [lines, query, prefs.ascending])
+
+  // The field census for the picker — rtail has no schema for a stream, so the
+  // only source of field names is the lines already in the buffer.
+  const availableFields = useMemo(
+    () => collectPaths(lines.filter((line) => 'object' === line.type).map((line) => line.content)),
+    [lines]
+  )
+
+  const fields = (activeStream && prefs.fields[activeStream]) || NO_FIELDS
+
+  const setFields = useCallback(
+    (next: string[]) => {
+      if (!activeStream) return
+
+      setPrefs((current) => {
+        const all = { ...current.fields }
+        if (next.length) all[activeStream] = next
+        else delete all[activeStream]
+
+        return { ...current, fields: all }
+      })
+    },
+    [activeStream]
+  )
+
   const isFavorite = !!activeStream && prefs.favorites.includes(activeStream)
 
   return (
@@ -138,9 +184,15 @@ export function App() {
         isFavorite={isFavorite}
         paused={paused}
         filter={filter}
+        filterError={query.error}
+        matched={visible.length}
+        total={lines.length}
+        fields={fields}
+        availableFields={availableFields}
         onChangePrefs={updatePrefs}
         onToggleFavorite={() => activeStream && toggleIn('favorites', activeStream)}
         onFilter={setFilter}
+        onFields={setFields}
       />
 
       <div class="split-pane">
@@ -154,8 +206,10 @@ export function App() {
 
         <StreamView
           activeStream={activeStream}
-          lines={lines}
-          filter={filter}
+          lines={visible}
+          needles={query.needles}
+          fields={fields}
+          jsonView={prefs.jsonView}
           ascending={prefs.ascending}
           timestampsHidden={!!activeStream && prefs.hiddenTimestamps.includes(activeStream)}
           paused={paused}

--- a/app/src/components/SearchBar.tsx
+++ b/app/src/components/SearchBar.tsx
@@ -1,0 +1,254 @@
+/*!
+ * The filter box, its syntax card, and the field picker.
+ *
+ * The three are one feature — the query and the extracted fields are the two
+ * halves of "show me this bit of the stream" — but they render in two places.
+ * The controls sit in the bar; the panels are handed back to TopBar, which
+ * mounts them outside it. `.topbar-main` is a query container, and layout
+ * containment makes it the containing block for anything fixed inside it,
+ * which would anchor the panels to the bar's box instead of the viewport.
+ */
+
+import { useEffect, useRef, useState } from 'preact/hooks'
+import type { RefObject } from 'preact'
+import { parsePath, type FieldPath } from '../lib/json.js'
+import { MAX_FIELDS } from '../lib/prefs.js'
+import { Popover } from './Popover.js'
+
+export type SearchPanel = 'help' | 'fields'
+
+interface Props {
+  value: string
+  /** Set when the query did not fully parse; shown on the box. */
+  error: string | null
+  matched: number
+  total: number
+  /** How many paths are extracted, for the badge on the button. */
+  fieldCount: number
+  open: SearchPanel | null
+  helpRef: RefObject<HTMLButtonElement>
+  fieldsRef: RefObject<HTMLButtonElement>
+  onChange: (value: string) => void
+  onToggle: (panel: SearchPanel) => void
+}
+
+const SYNTAX: Array<[string, string]> = [
+  ['payment failed', 'both words, in any order'],
+  ['"payment failed"', 'that exact phrase'],
+  ['-healthcheck', 'lines without it'],
+  ['/GET \\/1\\/users/', 'a regexp'],
+  ['level:error', 'JSON field contains'],
+  ['user.id=42', 'JSON field is exactly'],
+  ['duration>250', 'numeric comparison'],
+  ['trace_id:*', 'field is present']
+]
+
+export function SearchBar({
+  value,
+  error,
+  matched,
+  total,
+  fieldCount,
+  open,
+  helpRef,
+  fieldsRef,
+  onChange,
+  onToggle
+}: Props) {
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  // `f` jumps to the filter, the way `/` jumps to the stream search. Both stay
+  // out of the way of a field the user is already typing into.
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if ('f' !== event.key || event.metaKey || event.ctrlKey || event.altKey) return
+
+      const target = event.target as HTMLElement | null
+      if (target && /^(INPUT|TEXTAREA)$/.test(target.tagName)) return
+
+      event.preventDefault()
+      inputRef.current?.focus()
+      inputRef.current?.select()
+    }
+
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [])
+
+  return (
+    <>
+      <div class={`filter-box ${error ? 'invalid' : ''}`}>
+        <input
+          ref={inputRef}
+          type="text"
+          placeholder="Filter lines — text, /regexp/, level:error"
+          aria-label="Filter lines"
+          aria-invalid={error ? 'true' : undefined}
+          title={error ?? undefined}
+          value={value}
+          onInput={(event) => onChange(event.currentTarget.value)}
+          onKeyDown={(event) => {
+            if ('Escape' !== event.key) return
+            // Escape clears a query, or steps out of the field if it is empty.
+            if (value) onChange('')
+            else event.currentTarget.blur()
+          }}
+        />
+
+        {value && (
+          <span class="filter-count" title={`${matched} of ${total} lines match`}>
+            {matched}/{total}
+          </span>
+        )}
+
+        {value && (
+          <button
+            class="search-clear"
+            aria-label="Clear filter"
+            onClick={() => {
+              onChange('')
+              inputRef.current?.focus()
+            }}
+          />
+        )}
+
+        <button
+          ref={helpRef}
+          class="filter-help"
+          aria-label="Filter syntax"
+          aria-expanded={'help' === open}
+          onClick={() => onToggle('help')}
+        >
+          ?
+        </button>
+      </div>
+
+      <button
+        ref={fieldsRef}
+        class={`btn-fields ${fieldCount ? 'on' : ''}`}
+        aria-expanded={'fields' === open}
+        onClick={() => onToggle('fields')}
+      >
+        Fields
+        {fieldCount > 0 && <span class="btn-fields-count">{fieldCount}</span>}
+      </button>
+    </>
+  )
+}
+
+/** The syntax card behind the `?`. */
+export function SearchHelp({
+  anchor,
+  onClose
+}: {
+  anchor: HTMLElement | null
+  onClose: () => void
+}) {
+  return (
+    <Popover anchor={anchor} class="popover-help" onClose={onClose}>
+      <h4>Filter syntax</h4>
+
+      <dl>
+        {SYNTAX.map(([example, meaning]) => (
+          <div key={example}>
+            <dt>{example}</dt>
+            <dd>{meaning}</dd>
+          </div>
+        ))}
+      </dl>
+
+      <p class="hint">
+        Terms are ANDed. Case is ignored until a term contains a capital.
+      </p>
+    </Popover>
+  )
+}
+
+/**
+ * Picks the paths to extract.
+ *
+ * The list is the buffer's own field census rather than a fixed schema —
+ * rtail has no idea what a stream logs until it logs it — with a free-text
+ * path for the fields that have not come past yet.
+ */
+export function FieldsPicker({
+  anchor,
+  fields,
+  available,
+  onFields,
+  onClose
+}: {
+  anchor: HTMLElement | null
+  fields: string[]
+  available: FieldPath[]
+  onFields: (fields: string[]) => void
+  onClose: () => void
+}) {
+  const [draft, setDraft] = useState('')
+
+  const toggle = (path: string) => {
+    if (fields.includes(path)) onFields(fields.filter((field) => field !== path))
+    else if (fields.length < MAX_FIELDS) onFields([...fields, path])
+  }
+
+  const add = (event: Event) => {
+    event.preventDefault()
+
+    const path = draft.trim()
+    if (!path || !parsePath(path) || fields.includes(path)) return
+
+    onFields([...fields, path].slice(0, MAX_FIELDS))
+    setDraft('')
+  }
+
+  // Selected first, so a field keeps its place as the counts shuffle beneath
+  // it — and so a hand-typed path is still listed once the lines carrying it
+  // have scrolled out of the buffer.
+  const rows = [
+    ...fields.map((path) => ({
+      path,
+      count: available.find((field) => field.path === path)?.count ?? 0
+    })),
+    ...available.filter((field) => !fields.includes(field.path))
+  ]
+
+  return (
+    <Popover anchor={anchor} class="popover-fields" onClose={onClose}>
+      <h4>Extract fields</h4>
+      <p class="hint">Object lines collapse to the fields you pick.</p>
+
+      <form onSubmit={add}>
+        <input
+          type="text"
+          class="field-input"
+          placeholder="Add a path, e.g. req.headers.host"
+          aria-label="Add a field path"
+          value={draft}
+          onInput={(event) => setDraft(event.currentTarget.value)}
+        />
+      </form>
+
+      <div class="field-list">
+        {rows.map(({ path, count }) => (
+          <button
+            key={path}
+            class={`field-row ${fields.includes(path) ? 'on' : ''}`}
+            aria-pressed={fields.includes(path)}
+            onClick={() => toggle(path)}
+          >
+            <span class="field-path">{path}</span>
+            {count > 0 && <span class="field-count">{count}</span>}
+          </button>
+        ))}
+
+        {0 === rows.length && <p class="hint">No JSON fields in the buffer yet.</p>}
+      </div>
+
+      {fields.length > 0 && (
+        <button class="field-clear" onClick={() => onFields([])}>
+          Show full payloads
+        </button>
+      )}
+    </Popover>
+  )
+}

--- a/app/src/components/StreamView.tsx
+++ b/app/src/components/StreamView.tsx
@@ -1,11 +1,19 @@
-import { useEffect, useLayoutEffect, useMemo, useRef } from 'preact/hooks'
-import { buildFilter, formatTimestamp } from '../lib/format.js'
-import type { Line } from '../lib/types.js'
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'preact/hooks'
+import { defaultExpanded, formatTimestamp, renderFields } from '../lib/format.js'
+import { highlight } from '../lib/highlight.js'
+import type { Needle } from '../lib/query.js'
+import type { JsonView, Line } from '../lib/types.js'
 
 interface Props {
   activeStream: string | null
+  /** Already filtered and ordered by App, which also counts them for the bar. */
   lines: Line[]
-  filter: string
+  /** What to mark in each line; empty when the filter box is empty. */
+  needles: Needle[]
+  /** JSON paths to show instead of the whole payload. */
+  fields: string[]
+  jsonView: JsonView
+  /** Only the scroll anchor: App has already put the lines in this order. */
   ascending: boolean
   timestampsHidden: boolean
   paused: boolean
@@ -17,7 +25,9 @@ interface Props {
 export function StreamView({
   activeStream,
   lines,
-  filter,
+  needles,
+  fields,
+  jsonView,
   ascending,
   timestampsHidden,
   paused,
@@ -27,14 +37,33 @@ export function StreamView({
 }: Props) {
   const scrollerRef = useRef<HTMLDivElement>(null)
 
-  // Lines arrive in order, so insertion order is the source of truth. The old
-  // implementation re-sorted by timestamp on every digest, which reordered
-  // lines that shared a millisecond.
-  const visible = useMemo(() => {
-    const matches = buildFilter(filter)
-    const filtered = lines.filter(matches)
-    return ascending ? filtered : filtered.slice().reverse()
-  }, [lines, filter, ascending])
+  // Which individual payloads the user has opened or closed by hand. Keyed by
+  // line, so a row that has been opened stays open as lines arrive around it.
+  const [toggled, setToggled] = useState<Record<number, boolean>>({})
+
+  const toggle = useCallback((key: number, expanded: boolean) => {
+    setToggled((current) => ({ ...current, [key]: expanded }))
+  }, [])
+
+  // Keys are monotonic and the buffer is capped, so the map would only ever
+  // grow; a stream switch is the natural place to drop it.
+  useEffect(() => setToggled({}), [activeStream])
+
+  const rows = useMemo(() => {
+    return lines.map((line) => {
+      const expandable = null !== line.htmlCompact
+
+      // With fields picked, the projection *is* the collapsed form — otherwise
+      // "expand small payloads" would quietly undo the extraction.
+      const projected = fields.length ? renderFields(line.content, fields) : null
+      const fallback = projected ? false : defaultExpanded(jsonView, line)
+      const expanded = expandable && (toggled[line.key] ?? fallback)
+
+      const html = expanded ? line.html : (projected ?? line.htmlCompact ?? line.html)
+
+      return { line, expandable, expanded, html: highlight(html, needles) }
+    })
+  }, [lines, needles, fields, jsonView, toggled])
 
   // Follow the tail. Skipped while paused so the viewport stays where the user
   // scrolled to.
@@ -42,7 +71,7 @@ export function StreamView({
     const el = scrollerRef.current
     if (!el || paused) return
     el.scrollTop = ascending ? el.scrollHeight : 0
-  }, [visible, ascending, paused])
+  }, [rows, ascending, paused])
 
   // Scrolling away from the tail pauses the stream; the server stops sending
   // until the user resumes.
@@ -87,15 +116,29 @@ export function StreamView({
     // column and the control that sits on its edge cannot drift apart.
     <div class={`stream-view ${timestampsHidden ? 'no-timestamps' : ''}`}>
       <div class="stream-lines" ref={scrollerRef}>
-        {visible.map((line) => (
+        {rows.map(({ line, expandable, expanded, html }) => (
           <div class="stream-line" key={line.key}>
             {!timestampsHidden && (
               <div class="stream-line-timestamp">{formatTimestamp(line.timestamp)}</div>
             )}
+
             <div
-              class={`stream-line-content ${line.type}`}
-              dangerouslySetInnerHTML={{ __html: line.html }}
-            />
+              class={`stream-line-content ${line.type} ${
+                expandable ? (expanded ? 'json expanded' : 'json collapsed') : ''
+              }`}
+            >
+              {expandable && (
+                <button
+                  class="json-toggle"
+                  title={expanded ? 'Collapse payload' : 'Expand payload'}
+                  aria-label={expanded ? 'Collapse payload' : 'Expand payload'}
+                  aria-expanded={expanded}
+                  onClick={() => toggle(line.key, !expanded)}
+                />
+              )}
+
+              <div class="stream-line-body" dangerouslySetInnerHTML={{ __html: html }} />
+            </div>
           </div>
         ))}
       </div>

--- a/app/src/components/TopBar.tsx
+++ b/app/src/components/TopBar.tsx
@@ -1,7 +1,9 @@
 import { useRef, useState } from 'preact/hooks'
+import type { FieldPath } from '../lib/json.js'
 import { FONT_FAMILY_COUNT, FONT_SIZE_MAX, FONT_SIZE_MIN } from '../lib/prefs.js'
-import type { Prefs, Theme } from '../lib/types.js'
+import type { JsonView, Prefs, Theme } from '../lib/types.js'
 import { Popover } from './Popover.js'
+import { FieldsPicker, SearchBar, SearchHelp, type SearchPanel } from './SearchBar.js'
 
 declare const __VERSION__: string
 
@@ -11,12 +13,27 @@ interface Props {
   isFavorite: boolean
   paused: boolean
   filter: string
+  /** Set when the query did not fully parse. */
+  filterError: string | null
+  matched: number
+  total: number
+  /** Paths extracted from this stream's object lines. */
+  fields: string[]
+  /** Paths seen in the buffer, most common first. */
+  availableFields: FieldPath[]
   onChangePrefs: (patch: Partial<Prefs>) => void
   onToggleFavorite: () => void
   onFilter: (pattern: string) => void
+  onFields: (fields: string[]) => void
 }
 
-type OpenPanel = 'info' | 'settings' | null
+type OpenPanel = 'info' | 'settings' | SearchPanel | null
+
+const JSON_VIEWS: Array<[JsonView, string, string]> = [
+  ['auto', 'Auto', 'Expand small payloads, collapse the rest'],
+  ['collapsed', 'One line', 'Every payload on a single line'],
+  ['expanded', 'Pretty', 'Every payload expanded']
+]
 
 /**
  * The single top bar.
@@ -31,20 +48,32 @@ export function TopBar({
   isFavorite,
   paused,
   filter,
+  filterError,
+  matched,
+  total,
+  fields,
+  availableFields,
   onChangePrefs,
   onToggleFavorite,
-  onFilter
+  onFilter,
+  onFields
 }: Props) {
   const [open, setOpen] = useState<OpenPanel>(null)
   const infoRef = useRef<HTMLButtonElement>(null)
   const settingsRef = useRef<HTMLButtonElement>(null)
+  const helpRef = useRef<HTMLButtonElement>(null)
+  const fieldsRef = useRef<HTMLButtonElement>(null)
 
   const toggle = (panel: Exclude<OpenPanel, null>) =>
     setOpen((current) => (current === panel ? null : panel))
 
+  const close = () => setOpen(null)
+
   return (
-    // The popovers are siblings of the bar, not children, so bar-scoped styles
-    // cannot reach into them.
+    // The popovers are siblings of the bar, not children: bar-scoped styles
+    // cannot reach into them, and — since .topbar-main is a query container,
+    // which makes it the containing block for fixed descendants — a panel
+    // mounted inside would anchor to the bar's box rather than the viewport.
     <>
     <div class="topbar">
       <div class="topbar-brand">
@@ -68,15 +97,18 @@ export function TopBar({
               {paused ? 'Paused' : 'Live'}
             </span>
 
-            <div class="filter-box">
-              <input
-                type="text"
-                placeholder="filter stream (regexp allowed)"
-                aria-label="Filter stream"
-                value={filter}
-                onInput={(event) => onFilter(event.currentTarget.value)}
-              />
-            </div>
+            <SearchBar
+              value={filter}
+              error={filterError}
+              matched={matched}
+              total={total}
+              fieldCount={fields.length}
+              open={'help' === open || 'fields' === open ? open : null}
+              helpRef={helpRef}
+              fieldsRef={fieldsRef}
+              onChange={onFilter}
+              onToggle={toggle}
+            />
           </>
         )}
 
@@ -108,8 +140,20 @@ export function TopBar({
       </div>
     </div>
 
-    {'info' === open && (
-        <Popover anchor={infoRef.current} class="popover-info" onClose={() => setOpen(null)}>
+    {'help' === open && <SearchHelp anchor={helpRef.current} onClose={close} />}
+
+    {'fields' === open && (
+        <FieldsPicker
+          anchor={fieldsRef.current}
+          fields={fields}
+          available={availableFields}
+          onFields={onFields}
+          onClose={close}
+        />
+      )}
+
+      {'info' === open && (
+        <Popover anchor={infoRef.current} class="popover-info" onClose={close}>
           <div class="rtail-logo" />
           <div class="version">Version {__VERSION__}</div>
           <a
@@ -132,7 +176,7 @@ export function TopBar({
       )}
 
       {'settings' === open && (
-        <Popover anchor={settingsRef.current} class="popover-settings" onClose={() => setOpen(null)}>
+        <Popover anchor={settingsRef.current} class="popover-settings" onClose={close}>
           <h4>Font size</h4>
           <div class="btn-group">
             <button
@@ -180,6 +224,20 @@ export function TopBar({
               aria-label="Newest first"
               onClick={() => onChangePrefs({ ascending: false })}
             />
+          </div>
+
+          <h4>JSON payloads</h4>
+          <div class="btn-group">
+            {JSON_VIEWS.map(([view, label, title]) => (
+              <button
+                key={view}
+                class={`btn btn-text ${view === prefs.jsonView ? 'selected' : ''}`}
+                title={title}
+                onClick={() => onChangePrefs({ jsonView: view })}
+              >
+                {label}
+              </button>
+            ))}
           </div>
 
           <h4>Theme</h4>

--- a/app/src/lib/format.ts
+++ b/app/src/lib/format.ts
@@ -4,12 +4,18 @@
  * Each line is formatted exactly once, on arrival, and the result is cached on
  * the line object — rendering a 100-line viewport should never re-run the ANSI
  * parser or the syntax highlighter.
+ *
+ * Object lines are rendered twice, both times up front: expanded, and on one
+ * line. Which of the two a row shows is a display decision that changes with a
+ * preference or a click, and re-highlighting a payload on every such change
+ * would put the syntax highlighter back in the interaction path.
  */
 
 import { AnsiUp } from 'ansi_up'
 import hljs from 'highlight.js/lib/core'
 import json from 'highlight.js/lib/languages/json'
-import type { Line, WireLine } from './types.js'
+import { getPath, isPlainObject, parsePath, stringify } from './json.js'
+import type { JsonView, Line, WireLine } from './types.js'
 
 hljs.registerLanguage('json', json)
 
@@ -22,6 +28,15 @@ ansi.use_classes = true
 // Belt and braces: ansi_up escapes by default, and log lines are attacker
 // controlled (they are whatever a piped process printed).
 ansi.escape_html = true
+
+/**
+ * Rows of expanded JSON above which `auto` collapses a payload.
+ *
+ * Small objects are the ones worth reading in full — a `{ level, msg, ms }`
+ * costs three rows and saves a click. Past that a payload stops being a log
+ * line and starts being a document, and it pushes everything else off screen.
+ */
+const AUTO_EXPAND_ROWS = 6
 
 const timestampFormat = new Intl.DateTimeFormat(undefined, {
   year: '2-digit',
@@ -37,21 +52,89 @@ let nextKey = 0
 
 /** Formats a line for display, computing its HTML and filter text once. */
 export function formatLine(wire: WireLine): Line {
-  let html: string
-  let text: string
+  const base = { ...wire, htmlCompact: null, bulky: false, key: nextKey++ }
 
   if (null === wire.content || undefined === wire.content || '' === wire.content) {
-    html = ''
-    text = ''
-  } else if ('object' === wire.type) {
-    text = JSON.stringify(wire.content, null, '  ')
-    html = '<pre>' + hljs.highlight(text, { language: 'json' }).value + '</pre>'
-  } else {
-    text = String(wire.content)
-    html = ansi.ansi_to_html(text)
+    return { ...base, html: '', text: '' }
   }
 
-  return { ...wire, html, text, key: nextKey++ }
+  if ('object' === wire.type) {
+    const text = JSON.stringify(wire.content, null, '  ')
+
+    return {
+      ...base,
+      text,
+      html: `<pre>${highlightJson(text)}</pre>`,
+      htmlCompact: `<pre>${highlightJson(JSON.stringify(wire.content))}</pre>`,
+      bulky: rows(text) > AUTO_EXPAND_ROWS
+    }
+  }
+
+  const text = String(wire.content)
+  return { ...base, text, html: ansi.ansi_to_html(text) }
+}
+
+/** Whether an object line starts out expanded, before anyone clicks a caret. */
+export function defaultExpanded(view: JsonView, line: Line): boolean {
+  if ('expanded' === view) return true
+  if ('collapsed' === view) return false
+
+  return !line.bulky
+}
+
+/**
+ * Renders a payload as just the fields that were asked for.
+ *
+ * `logfmt` shape rather than JSON: at one field per column the braces and
+ * quotes are most of the row. Fields the line does not carry are dropped
+ * instead of rendered empty — a stream is rarely uniform, and a row of
+ * placeholders reads as data.
+ *
+ * Returns null when the line carries none of them, so the caller can fall back
+ * to showing the payload rather than an empty row.
+ */
+export function renderFields(content: unknown, fields: string[]): string | null {
+  if (!isPlainObject(content)) return null
+
+  const pairs: string[] = []
+
+  for (const field of fields) {
+    const path = parsePath(field)
+    if (!path) continue
+
+    const value = getPath(content, path)
+    if (undefined === value) continue
+
+    pairs.push(
+      `<span class="field-pair">` +
+        `<span class="field-key">${escapeHtml(field)}</span>` +
+        `<span class="field-eq">=</span>` +
+        renderValue(value) +
+        `</span>`
+    )
+  }
+
+  return pairs.length ? `<pre>${pairs.join(' ')}</pre>` : null
+}
+
+function renderValue(value: unknown): string {
+  if ('string' === typeof value) {
+    // Quoted only where the quotes earn their place: without them a value with
+    // spaces in it reads as the start of the next pair.
+    const text = /[\s"]/.test(value) ? JSON.stringify(value) : value
+    return `<span class="hljs-string">${escapeHtml(text)}</span>`
+  }
+
+  if ('number' === typeof value) {
+    return `<span class="hljs-number">${escapeHtml(String(value))}</span>`
+  }
+
+  if ('boolean' === typeof value || null === value) {
+    return `<span class="hljs-literal">${escapeHtml(stringify(value))}</span>`
+  }
+
+  // Objects and arrays keep their syntax highlighting; they are still JSON.
+  return highlightJson(stringify(value))
 }
 
 export function formatTimestamp(timestamp: number): string {
@@ -60,20 +143,23 @@ export function formatTimestamp(timestamp: number): string {
   return timestampFormat.format(new Date(timestamp)).replace(',', '')
 }
 
-/**
- * Builds a line predicate from the filter box.
- *
- * The input is a regexp; while it is being typed it is usually invalid, and a
- * half-written pattern should not blank the viewport — so anything that fails
- * to compile matches everything.
- */
-export function buildFilter(pattern: string): (line: Line) => boolean {
-  if (!pattern) return () => true
+function highlightJson(text: string): string {
+  return hljs.highlight(text, { language: 'json' }).value
+}
 
-  try {
-    const re = new RegExp(pattern)
-    return (line) => re.test(line.text)
-  } catch {
-    return () => true
+function rows(text: string): number {
+  let count = 1
+  for (let index = text.indexOf('\n'); -1 !== index; index = text.indexOf('\n', index + 1)) {
+    count++
   }
+
+  return count
+}
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
 }

--- a/app/src/lib/highlight.ts
+++ b/app/src/lib/highlight.ts
@@ -1,0 +1,109 @@
+/*!
+ * Marking query hits in a line that is already rendered.
+ *
+ * The line's HTML comes out of the ANSI parser or the syntax highlighter, so
+ * the marks cannot be applied with a string replace — that would rewrite tag
+ * names and attributes as readily as text. Instead the fragment is parsed and
+ * only its text nodes are touched, which also means a mark can never break the
+ * surrounding markup.
+ *
+ * A hit that spans two text nodes — a phrase split across ANSI colour changes,
+ * or across the newline of a pretty-printed payload — is not marked. Marking
+ * it would mean splitting elements, and the filter has already done the useful
+ * part by keeping the line.
+ */
+
+import type { Needle } from './query.js'
+
+type Range = [start: number, end: number]
+
+export function highlight(html: string, needles: Needle[]): string {
+  if (!html || 0 === needles.length) return html
+
+  const template = document.createElement('template')
+  template.innerHTML = html
+
+  const walker = document.createTreeWalker(template.content, NodeFilter.SHOW_TEXT)
+  const nodes: Text[] = []
+  for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+    nodes.push(node as Text)
+  }
+
+  let marked = false
+
+  for (const node of nodes) {
+    const text = node.data
+    const ranges = findRanges(text, needles)
+    if (0 === ranges.length) continue
+
+    const fragment = document.createDocumentFragment()
+    let cursor = 0
+
+    for (const [start, end] of ranges) {
+      if (start > cursor) fragment.append(text.slice(cursor, start))
+
+      const mark = document.createElement('mark')
+      mark.textContent = text.slice(start, end)
+      fragment.append(mark)
+
+      cursor = end
+    }
+
+    if (cursor < text.length) fragment.append(text.slice(cursor))
+
+    node.replaceWith(fragment)
+    marked = true
+  }
+
+  return marked ? template.innerHTML : html
+}
+
+/** Every hit in the string, sorted and with overlaps merged into one mark. */
+function findRanges(text: string, needles: Needle[]): Range[] {
+  const ranges: Range[] = []
+
+  for (const needle of needles) {
+    if ('literal' === needle.type) {
+      if (!needle.value) continue
+
+      const haystack = needle.caseSensitive ? text : text.toLowerCase()
+      const target = needle.caseSensitive ? needle.value : needle.value.toLowerCase()
+
+      for (
+        let index = haystack.indexOf(target);
+        -1 !== index;
+        index = haystack.indexOf(target, index + target.length)
+      ) {
+        ranges.push([index, index + target.length])
+      }
+
+      continue
+    }
+
+    // A fresh regexp per pass: the query's own instance is shared by every
+    // line, and a sticky `lastIndex` would make the marks depend on the order
+    // the rows happened to render in.
+    const re = new RegExp(needle.re.source, needle.re.flags + 'g')
+
+    for (let match = re.exec(text); match; match = re.exec(text)) {
+      if (match[0]) ranges.push([match.index, match.index + match[0].length])
+      else re.lastIndex++ // an empty match, from something like /x*/
+
+      if (re.lastIndex > text.length) break
+    }
+  }
+
+  if (ranges.length < 2) return ranges
+
+  ranges.sort((a, b) => a[0] - b[0])
+
+  const merged: Range[] = [ranges[0]]
+
+  for (const [start, end] of ranges.slice(1)) {
+    const last = merged[merged.length - 1]
+    if (start <= last[1]) last[1] = Math.max(last[1], end)
+    else merged.push([start, end])
+  }
+
+  return merged
+}

--- a/app/src/lib/json.ts
+++ b/app/src/lib/json.ts
@@ -1,0 +1,143 @@
+/*!
+ * JSON field paths.
+ *
+ * Both halves of the JSON work need the same primitive: a dotted path, parsed
+ * once, read out of a payload. `level`, `user.id`, `items[0].sku`.
+ *
+ * Only paths that can be typed back into the filter box are ever produced —
+ * a key with a dot or a space in it cannot be addressed, so it is left out of
+ * the suggestions rather than offered and then not working.
+ */
+
+export type Path = Array<string | number>
+
+/** A path seen in the buffer, and how many lines carry it. */
+export interface FieldPath {
+  path: string
+  count: number
+}
+
+/** Depth beyond which nested objects are shown whole rather than descended. */
+const MAX_DEPTH = 4
+
+const KEY = /^[A-Za-z_$][\w$-]*$/
+
+/** Parses `items[0].sku` into `['items', 0, 'sku']`, or null if malformed. */
+export function parsePath(input: string): Path | null {
+  const path: Path = []
+  let segment = ''
+  let closed = false
+
+  for (let index = 0; index < input.length; index++) {
+    const char = input[index]
+
+    if ('.' === char) {
+      if (segment) path.push(segment)
+      else if (!closed) return null
+      segment = ''
+      closed = false
+      continue
+    }
+
+    if ('[' === char) {
+      const end = input.indexOf(']', index)
+      if (-1 === end) return null
+
+      const subscript = input.slice(index + 1, end)
+      if (!/^\d+$/.test(subscript)) return null
+
+      if (segment) path.push(segment)
+      path.push(Number(subscript))
+      segment = ''
+      closed = true
+      index = end
+      continue
+    }
+
+    if (closed) return null
+    segment += char
+  }
+
+  if (segment) path.push(segment)
+  return path.length ? path : null
+}
+
+/**
+ * Reads a path out of a payload, or undefined if any hop is missing.
+ *
+ * Own properties only: `__proto__.constructor` is a path a user can type, and
+ * walking into the prototype chain would answer it with something that is not
+ * in their log line.
+ */
+export function getPath(value: unknown, path: Path): unknown {
+  let current = value
+
+  for (const key of path) {
+    if (null === current || 'object' !== typeof current) return undefined
+
+    if ('number' === typeof key) {
+      if (!Array.isArray(current)) return undefined
+      current = current[key]
+    } else {
+      if (!Object.prototype.hasOwnProperty.call(current, key)) return undefined
+      current = (current as Record<string, unknown>)[key]
+    }
+
+    if (undefined === current) return undefined
+  }
+
+  return current
+}
+
+/**
+ * The paths present in a set of payloads, most common first.
+ *
+ * Arrays count as leaves: `items` is a field you can extract, `items[0].sku`
+ * is one you have to type. Suggesting a path per array element would bury the
+ * fields that actually repeat across lines.
+ */
+export function collectPaths(contents: unknown[], limit = 40): FieldPath[] {
+  const counts = new Map<string, number>()
+
+  const walk = (value: unknown, prefix: string, depth: number) => {
+    for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+      if (!KEY.test(key)) continue
+
+      const label = prefix ? `${prefix}.${key}` : key
+
+      if (isPlainObject(child) && depth < MAX_DEPTH) walk(child, label, depth + 1)
+      else counts.set(label, (counts.get(label) ?? 0) + 1)
+    }
+  }
+
+  for (const content of contents) {
+    if (isPlainObject(content)) walk(content, '', 1)
+  }
+
+  return [...counts]
+    .map(([path, count]) => ({ path, count }))
+    .sort((a, b) => b.count - a.count || a.path.localeCompare(b.path))
+    .slice(0, limit)
+}
+
+export function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return null !== value && 'object' === typeof value && !Array.isArray(value)
+}
+
+/** How a value reads inside a query or a `key=value` pair. */
+export function stringify(value: unknown): string {
+  if ('string' === typeof value) return value
+  if (null === value) return 'null'
+
+  if ('object' === typeof value) {
+    try {
+      return JSON.stringify(value) ?? ''
+    } catch {
+      // Cyclic payloads cannot arrive over the wire, but a getter that throws
+      // is not worth taking the viewport down for.
+      return ''
+    }
+  }
+
+  return String(value)
+}

--- a/app/src/lib/prefs.ts
+++ b/app/src/lib/prefs.ts
@@ -7,13 +7,16 @@
  * flashing the default while an async store resolves.
  */
 
-import type { Prefs, Theme } from './types.js'
+import type { JsonView, Prefs, Theme } from './types.js'
 
 const KEY = 'rtail:prefs'
 
 export const FONT_SIZE_MIN = 1
 export const FONT_SIZE_MAX = 7
 export const FONT_FAMILY_COUNT = 6
+
+/** Extracted fields per stream — a hard cap, since they render side by side. */
+export const MAX_FIELDS = 12
 
 const DEFAULTS: Prefs = {
   theme: 'dark',
@@ -22,7 +25,9 @@ const DEFAULTS: Prefs = {
   ascending: true,
   sidebarWidth: 240,
   favorites: [],
-  hiddenTimestamps: []
+  hiddenTimestamps: [],
+  jsonView: 'auto',
+  fields: {}
 }
 
 function clamp(value: number, min: number, max: number): number {
@@ -51,8 +56,29 @@ export function loadPrefs(): Prefs {
     favorites: Array.isArray(stored.favorites) ? stored.favorites.filter(isString) : [],
     hiddenTimestamps: Array.isArray(stored.hiddenTimestamps)
       ? stored.hiddenTimestamps.filter(isString)
-      : []
+      : [],
+    jsonView: isJsonView(stored.jsonView) ? stored.jsonView : DEFAULTS.jsonView,
+    fields: readFields(stored.fields)
   }
+}
+
+function readFields(stored: unknown): Record<string, string[]> {
+  if (null === stored || 'object' !== typeof stored) return {}
+
+  const fields: Record<string, string[]> = {}
+
+  for (const [stream, paths] of Object.entries(stored)) {
+    if (!Array.isArray(paths)) continue
+
+    const clean = paths.filter(isString).slice(0, MAX_FIELDS)
+    if (clean.length) fields[stream] = clean
+  }
+
+  return fields
+}
+
+function isJsonView(value: unknown): value is JsonView {
+  return 'auto' === value || 'collapsed' === value || 'expanded' === value
 }
 
 export function savePrefs(prefs: Prefs): void {

--- a/app/src/lib/query.ts
+++ b/app/src/lib/query.ts
@@ -1,0 +1,297 @@
+/*!
+ * The filter box's query language.
+ *
+ * It used to be a bare regexp over the rendered text, which is the wrong tool
+ * the moment the lines are JSON: `level.*error` happily matches a payload
+ * whose `level` is `info` and whose message three keys away says "error". So
+ * the box now parses a small language — terms ANDed together, each one
+ * negatable, and field terms that address the parsed payload instead of its
+ * text.
+ *
+ *   payment failed     both words, anywhere in the line
+ *   "payment failed"   that phrase
+ *   -healthcheck       lines without it
+ *   /GET \/1\/users/   an explicit regexp
+ *   level:error        the JSON field contains "error"
+ *   user.id=42         the field is exactly that
+ *   duration>250       numeric comparison
+ *   trace_id:*         the field is there at all
+ *
+ * Matching is case-insensitive until a term contains an uppercase letter (the
+ * smart-case convention from ag and ripgrep), so the common case needs no
+ * flags and a deliberate `Error` still means `Error`.
+ *
+ * A field term never matches a line without that field — including `!=`. That
+ * makes `status!=200` mean "a status, and not 200"; for "not 200, whether or
+ * not there is a status" the negated form `-status:200` is the one to reach
+ * for.
+ */
+
+import { getPath, parsePath, stringify, type Path } from './json.js'
+
+/** Longest first, so `>=` is never read as `>` followed by a value of `=1`. */
+const OPERATORS = ['!=', '>=', '<=', ':', '=', '>', '<'] as const
+
+type Operator = (typeof OPERATORS)[number]
+
+/** A path that can be typed: the same shape the suggestions offer. */
+const PATH = /^[A-Za-z_$][\w$-]*(?:\.[\w$-]+|\[\d+\])*$/
+
+/** Flags worth honouring. `g` and `y` carry state between calls; drop them. */
+const FLAGS = /[^imsu]/g
+
+export type Needle =
+  | { type: 'literal'; value: string; caseSensitive: boolean }
+  | { type: 'regexp'; re: RegExp }
+
+interface TextTerm {
+  kind: 'text'
+  negated: boolean
+  needle: Needle
+}
+
+interface FieldTerm {
+  kind: 'field'
+  negated: boolean
+  path: Path
+  op: Operator
+  /** null for `field:*`, which asks only whether the field is there. */
+  needle: Needle | null
+  /** The right-hand side as a number, parsed once for the comparisons. */
+  number: number
+}
+
+export type Term = TextTerm | FieldTerm
+
+export interface Query {
+  /** Every term has to match. No terms means every line matches. */
+  terms: Term[]
+  /** What to mark in the matching lines: the positive terms' needles. */
+  needles: Needle[]
+  /** Set when part of the input did not parse. The rest still filters. */
+  error: string | null
+  isEmpty: boolean
+}
+
+const EMPTY: Query = { terms: [], needles: [], error: null, isEmpty: true }
+
+export function parseQuery(input: string): Query {
+  if (!input.trim()) return EMPTY
+
+  const terms: Term[] = []
+  let error: string | null = null
+
+  for (const token of tokenize(input)) {
+    try {
+      const term = parseToken(token)
+      if (term) terms.push(term)
+    } catch (err) {
+      // A half-typed regexp is the normal state of a box being typed into.
+      // The terms that did parse keep filtering, and the box says why.
+      error ??= (err as Error).message
+    }
+  }
+
+  // Only the terms whose value is text the line actually contains. The bound
+  // in `duration>250` is not something to mark: the payloads that match it are
+  // precisely the ones that do not say 250.
+  const needles = terms
+    .filter((term) => !term.negated && ('text' === term.kind || ':' === term.op || '=' === term.op))
+    .map((term) => term.needle)
+    .filter((needle): needle is Needle => null !== needle)
+
+  return { terms, needles, error, isEmpty: 0 === terms.length }
+}
+
+export function matchesQuery(query: Query, line: { text: string; content: unknown }): boolean {
+  for (const term of query.terms) {
+    const hit =
+      'text' === term.kind
+        ? matchNeedle(term.needle, line.text)
+        : matchField(term, line.content)
+
+    if (hit === term.negated) return false
+  }
+
+  return true
+}
+
+export function matchNeedle(needle: Needle, text: string): boolean {
+  if ('regexp' === needle.type) return needle.re.test(text)
+  if (needle.caseSensitive) return text.includes(needle.value)
+
+  return text.toLowerCase().includes(needle.value.toLowerCase())
+}
+
+function matchField(term: FieldTerm, content: unknown): boolean {
+  const value = getPath(content, term.path)
+  if (undefined === value) return false
+  if (null === term.needle) return true
+
+  switch (term.op) {
+    case ':':
+      return matchNeedle(term.needle, stringify(value))
+    case '=':
+      return equals(term.needle, value)
+    case '!=':
+      return !equals(term.needle, value)
+    default: {
+      const left = toNumber(value)
+      if (Number.isNaN(left) || Number.isNaN(term.number)) return false
+
+      if ('>' === term.op) return left > term.number
+      if ('>=' === term.op) return left >= term.number
+      if ('<' === term.op) return left < term.number
+      return left <= term.number
+    }
+  }
+}
+
+function equals(needle: Needle, value: unknown): boolean {
+  const text = stringify(value)
+  if ('regexp' === needle.type) return needle.re.test(text)
+  if (needle.caseSensitive) return text === needle.value
+
+  return text.toLowerCase() === needle.value.toLowerCase()
+}
+
+function toNumber(value: unknown): number {
+  if ('number' === typeof value) return value
+  if ('string' === typeof value && value.trim()) return Number(value)
+
+  return Number.NaN
+}
+
+/**
+ * Splits on whitespace, except inside quotes and regexps — the two places a
+ * space is part of the term rather than the end of it.
+ */
+function tokenize(input: string): string[] {
+  const tokens: string[] = []
+  let token = ''
+  let quote: string | null = null
+  let inRegexp = false
+
+  for (let index = 0; index < input.length; index++) {
+    const char = input[index]
+
+    if ('\\' === char && (quote || inRegexp) && index + 1 < input.length) {
+      token += char + input[++index]
+      continue
+    }
+
+    if (quote) {
+      if (char === quote) quote = null
+      token += char
+      continue
+    }
+
+    if (inRegexp) {
+      if ('/' === char) inRegexp = false
+      token += char
+      continue
+    }
+
+    if ('"' === char || "'" === char) {
+      quote = char
+      token += char
+      continue
+    }
+
+    // A slash opens a regexp only where a value can start; anywhere else it is
+    // part of a path being searched for, as in `GET /1/users`.
+    if ('/' === char && startsValue(token)) {
+      inRegexp = true
+      token += char
+      continue
+    }
+
+    if (/\s/.test(char)) {
+      if (token) tokens.push(token)
+      token = ''
+      continue
+    }
+
+    token += char
+  }
+
+  if (token) tokens.push(token)
+  return tokens
+}
+
+function startsValue(token: string): boolean {
+  return /^[-!]?$/.test(token) || OPERATORS.some((op) => token.endsWith(op))
+}
+
+function parseToken(token: string): Term | null {
+  const negated = token.startsWith('-') || token.startsWith('!')
+  const rest = negated ? token.slice(1) : token
+  if (!rest) return null
+
+  const field = splitField(rest)
+  if (!field) return { kind: 'text', negated, needle: parseNeedle(rest) }
+
+  const wildcard = ':' === field.op && '*' === field.value
+  const needle = wildcard ? null : parseNeedle(field.value)
+
+  return {
+    kind: 'field',
+    negated,
+    path: field.path,
+    op: field.op,
+    needle,
+    number: needle && 'literal' === needle.type ? Number(needle.value) : Number.NaN
+  }
+}
+
+function splitField(token: string): { path: Path; op: Operator; value: string } | null {
+  let found: { index: number; op: Operator } | null = null
+
+  for (const op of OPERATORS) {
+    const index = token.indexOf(op)
+    if (-1 === index) continue
+    if (!found || index < found.index) found = { index, op }
+  }
+
+  if (!found || 0 === found.index) return null
+
+  const head = token.slice(0, found.index)
+  const value = token.slice(found.index + found.op.length)
+
+  if (!PATH.test(head)) return null
+
+  // `https://example.com` is a URL someone is looking for, not a query about a
+  // field called `https`.
+  if (':' === found.op && value.startsWith('//')) return null
+
+  const path = parsePath(head)
+  return path ? { path, op: found.op, value } : null
+}
+
+function parseNeedle(raw: string): Needle {
+  const regexp = /^\/(.+)\/([a-z]*)$/.exec(raw)
+
+  if (regexp) {
+    const [, source, given] = regexp
+    let flags = given.replace(FLAGS, '')
+
+    // Smart case, the regexp spelling of it.
+    if (!flags.includes('i') && !/[A-Z]/.test(source)) flags += 'i'
+
+    try {
+      return { type: 'regexp', re: new RegExp(source, flags) }
+    } catch (err) {
+      throw new Error((err as Error).message)
+    }
+  }
+
+  const value = unquote(raw)
+  return { type: 'literal', value, caseSensitive: /[A-Z]/.test(value) }
+}
+
+function unquote(raw: string): string {
+  const quoted = /^"(.*)"$/.exec(raw) ?? /^'(.*)'$/.exec(raw)
+  if (!quoted) return raw
+
+  return quoted[1].replace(/\\(["'\\])/g, '$1')
+}

--- a/app/src/lib/types.ts
+++ b/app/src/lib/types.ts
@@ -13,13 +13,20 @@ export interface WireLine {
 export interface Line extends WireLine {
   /** Pre-rendered, already-escaped HTML for the line body. */
   html: string
-  /** Plain text used for the regexp filter. */
+  /** The same payload on one line; null for anything that is not an object. */
+  htmlCompact: string | null
+  /** True when the expanded payload is taller than the auto-collapse cutoff. */
+  bulky: boolean
+  /** Plain text used for the filter. */
   text: string
   /** Monotonic id, so the list can be keyed without relying on timestamps. */
   key: number
 }
 
 export type Theme = 'dark' | 'light'
+
+/** How object lines render before anyone touches an individual one. */
+export type JsonView = 'auto' | 'collapsed' | 'expanded'
 
 export interface Prefs {
   theme: Theme
@@ -33,4 +40,10 @@ export interface Prefs {
   favorites: string[]
   /** Streams whose timestamp column is collapsed. */
   hiddenTimestamps: string[]
+  jsonView: JsonView
+  /**
+   * Extracted JSON paths, per stream — the fields are a property of the shape
+   * a stream logs, so they follow the stream rather than the window.
+   */
+  fields: Record<string, string[]>
 }

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -1,0 +1,155 @@
+import assert from 'node:assert/strict'
+import { fileURLToPath } from 'node:url'
+import { describe, it } from 'node:test'
+import * as esbuild from 'esbuild'
+
+/**
+ * The filter box's query language.
+ *
+ * The webapp is TypeScript and the test runner is plain node, so the module
+ * under test is bundled in memory first — the same esbuild the build uses,
+ * with no build step to keep in sync and nothing written to disk.
+ */
+const entry = fileURLToPath(new URL('../app/src/lib/query.ts', import.meta.url))
+
+const bundle = await esbuild.build({
+  entryPoints: [entry],
+  bundle: true,
+  format: 'esm',
+  write: false,
+  logLevel: 'silent'
+})
+
+const { parseQuery, matchesQuery } = await import(
+  `data:text/javascript;base64,${Buffer.from(bundle.outputFiles[0].text).toString('base64')}`
+)
+
+/** A line as StreamView sees it: rendered text, plus the payload it came from. */
+const line = (content) =>
+  'string' === typeof content
+    ? { text: content, content }
+    : { text: JSON.stringify(content, null, '  '), content }
+
+const matches = (query, content) => matchesQuery(parseQuery(query), line(content))
+
+describe('query: text terms', () => {
+  it('matches every line when empty', () => {
+    assert.equal(parseQuery('').isEmpty, true)
+    assert.equal(matches('', 'anything'), true)
+    assert.equal(matches('   ', 'anything'), true)
+  })
+
+  it('ANDs the terms, in any order', () => {
+    assert.equal(matches('payment failed', 'payment gateway failed'), true)
+    assert.equal(matches('failed payment', 'payment gateway failed'), true)
+    assert.equal(matches('payment refunded', 'payment gateway failed'), false)
+  })
+
+  it('keeps a quoted phrase together', () => {
+    assert.equal(matches('"payment failed"', 'the payment failed'), true)
+    assert.equal(matches('"payment failed"', 'payment gateway failed'), false)
+  })
+
+  it('negates with a leading dash', () => {
+    assert.equal(matches('-healthcheck', 'GET /users'), true)
+    assert.equal(matches('-healthcheck', 'GET /healthcheck'), false)
+  })
+
+  it('ignores case until a term has a capital', () => {
+    assert.equal(matches('error', 'ERROR: nope'), true)
+    assert.equal(matches('ERROR', 'error: nope'), false)
+    assert.equal(matches('ERROR', 'ERROR: nope'), true)
+  })
+
+  it('takes a regexp between slashes', () => {
+    assert.equal(matches('/GET \\/1\\/users/', 'GET /1/users 200'), true)
+    assert.equal(matches('/GET \\/1\\/users/', 'POST /1/users 200'), false)
+  })
+
+  it('searches a bare slash as text, not as a regexp', () => {
+    assert.equal(matches('/1/users', 'GET /1/users'), true)
+    assert.equal(matches('https://example.com', 'GET https://example.com'), true)
+  })
+
+  it('keeps filtering on the terms that parsed when one does not', () => {
+    const query = parseQuery('boom /unclosed(/')
+
+    assert.notEqual(query.error, null)
+    assert.equal(matchesQuery(query, line('boom')), true)
+    assert.equal(matchesQuery(query, line('quiet')), false)
+  })
+})
+
+describe('query: field terms', () => {
+  const payload = {
+    level: 'error',
+    duration: 250,
+    ok: false,
+    user: { id: 42, name: 'Ada' },
+    tags: ['a', 'b']
+  }
+
+  it('matches a field by substring', () => {
+    assert.equal(matches('level:err', payload), true)
+    assert.equal(matches('level:warn', payload), false)
+  })
+
+  it('walks a dotted path', () => {
+    assert.equal(matches('user.name:ada', payload), true)
+    assert.equal(matches('user.id=42', payload), true)
+    assert.equal(matches('user.missing:x', payload), false)
+  })
+
+  it('indexes into arrays', () => {
+    assert.equal(matches('tags[1]=b', payload), true)
+    assert.equal(matches('tags[1]=a', payload), false)
+  })
+
+  it('compares numbers', () => {
+    assert.equal(matches('duration>100', payload), true)
+    assert.equal(matches('duration>250', payload), false)
+    assert.equal(matches('duration>=250', payload), true)
+    assert.equal(matches('duration<100', payload), false)
+  })
+
+  it('distinguishes exact from contains', () => {
+    assert.equal(matches('level=error', payload), true)
+    assert.equal(matches('level=err', payload), false)
+    assert.equal(matches('level!=warn', payload), true)
+  })
+
+  it('asks whether a field is there at all', () => {
+    assert.equal(matches('user.id:*', payload), true)
+    assert.equal(matches('trace_id:*', payload), false)
+  })
+
+  it('never matches a line without the field, including with !=', () => {
+    assert.equal(matches('level!=error', 'a plain text line'), false)
+    assert.equal(matches('level:error', 'the level is error'), false)
+  })
+
+  it('reads booleans and nested objects as text', () => {
+    assert.equal(matches('ok=false', payload), true)
+    assert.equal(matches('user:Ada', payload), true)
+  })
+
+  it('does not walk into the prototype chain', () => {
+    assert.equal(matches('constructor:*', payload), false)
+  })
+})
+
+describe('query: highlighting', () => {
+  it('offers the positive terms as needles', () => {
+    const query = parseQuery('boom -quiet level:error')
+
+    assert.deepEqual(
+      query.needles.map((needle) => needle.value),
+      ['boom', 'error']
+    )
+  })
+
+  it('leaves out the bound of a comparison, which no line contains', () => {
+    assert.deepEqual(parseQuery('duration>250').needles, [])
+    assert.deepEqual(parseQuery('trace_id:*').needles, [])
+  })
+})


### PR DESCRIPTION
## The filter box is a query language now

A bare regexp over rendered text is the wrong tool once the lines are JSON — `level.*error` matches a payload whose `level` is `info` and whose message three keys away says "error". Terms are ANDed, each one negatable:

| Query | Matches |
| --- | --- |
| `payment failed` | both words, in any order |
| `"payment failed"` | that exact phrase |
| `-healthcheck` | lines without it |
| `/GET \/1\/users/` | a regexp |
| `level:error` | JSON field contains |
| `user.id=42` / `status!=200` | exact / not |
| `duration>250` | numeric comparison |
| `trace_id:*` | field is present |

Case is ignored until a term contains a capital (the ag/rg convention). Hits are marked in the viewport, the box counts survivors, `f` focuses it and `Escape` clears it, and a `?` opens the syntax card.

Three decisions worth reviewing:

- **A field term never matches a line without the field, `!=` included.** `status!=200` means "has a status, and it is not 200"; `-status:200` is the form that also keeps lines with no status. Documented in the README.
- **A half-typed regexp keeps filtering** on the terms that did parse, and turns the box's hairline red — an input being typed into is invalid most of the time, and blanking the viewport on every keystroke is worse than a partial answer.
- **Marks are applied by walking text nodes** of the parsed fragment, never by string-replacing HTML that the ANSI parser and the syntax highlighter produced. A hit spanning two text nodes goes unmarked rather than splitting elements.

## Fields extracts JSON paths

`event=checkout.completed count=305 ok=false` instead of the whole payload. The path list is a census of the buffer, most common first — rtail has no schema for a stream until it logs one — plus a free-text path for anything not seen yet. Picks are stored per stream, since a billing worker's fields are not an nginx log's.

## Not every payload is worth six rows

**Settings → JSON payloads**: *Auto* (expanded up to six rows, collapsed past that — the new default), *One line*, *Pretty*. A caret on any object line overrides its own row, whether it is showing a payload or extracted fields. Both renderings are computed once on arrival, so toggling never re-runs the highlighter.

## Also in here

- Filtering and ordering move from `StreamView` up to `App`: the bar shows how many lines survived, so the viewport should not be the only thing that knows.
- The filter takes the full width of the bar. The auto margin that pins the action icons moves onto them — it hung off `:has(.filter-box)`, which still matches once the container query hides the filter, so on a narrow bar nothing was pushed to the edge.
- `_highlightjs.scss` referenced two variables that do not exist (`--text-secondary`, `--text-faint`); they now point at real tokens.

## Testing

11 new tests for the query language. `test/query.test.js` bundles the TypeScript in memory with the same esbuild the build uses, so there is no compile step to keep in sync and nothing written to disk. Suite is 44/44, `make typecheck` and `make dist` clean. Verified in the browser: filtering and marking in both themes, the field picker, per-line and global expansion, the invalid-query state, and the bar at 1400px and 800px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)